### PR TITLE
5 implement alpaca trading client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,7 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Mac OSX
+.DS_Store
+

--- a/examples/alpaca/alpaca_buy_sell.ipynb
+++ b/examples/alpaca/alpaca_buy_sell.ipynb
@@ -1,0 +1,267 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "3d2d2986-8f0f-4112-b2a2-03b767dffc76",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "from dotenv import load_dotenv\n",
+    "import os\n",
+    "import requests\n",
+    "import alpaca_trade_api as tradeapi\n",
+    "import datetime\n",
+    "from alpaca.trading.client import TradingClient\n",
+    "from alpaca.trading.requests import MarketOrderRequest\n",
+    "from alpaca.trading.enums import OrderSide, TimeInForce"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "2a1a696d-9cc5-484a-b3bf-1aa0b010162b",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "load_dotenv()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "559f825e-3b85-4576-9416-686c4c1c822f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Set api_key and secret_key\n",
+    "alpaca_api_key = os.getenv(\"ALPACA_API_KEY\")\n",
+    "alpaca_secret_key = os.getenv(\"ALPACA_SECRET_KEY\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "4d116e07-0328-4bbe-84d9-8c5d46c0eb7d",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{   'asset_class': <AssetClass.CRYPTO: 'crypto'>,\n",
+       "    'asset_id': UUID('a1733398-6acc-4e92-af24-0d0667f78713'),\n",
+       "    'canceled_at': None,\n",
+       "    'client_order_id': '9f347eff-9de9-49b9-8b1e-172e57e241c1',\n",
+       "    'created_at': datetime.datetime(2022, 9, 30, 2, 58, 37, 469102, tzinfo=datetime.timezone.utc),\n",
+       "    'expired_at': None,\n",
+       "    'extended_hours': False,\n",
+       "    'failed_at': None,\n",
+       "    'filled_at': None,\n",
+       "    'filled_avg_price': None,\n",
+       "    'filled_qty': '0',\n",
+       "    'hwm': None,\n",
+       "    'id': UUID('9d113135-171c-42a0-b30b-bc95415df4fa'),\n",
+       "    'legs': None,\n",
+       "    'limit_price': None,\n",
+       "    'notional': None,\n",
+       "    'order_class': <OrderClass.SIMPLE: 'simple'>,\n",
+       "    'order_type': <OrderType.MARKET: 'market'>,\n",
+       "    'qty': '0.676',\n",
+       "    'replaced_at': None,\n",
+       "    'replaced_by': None,\n",
+       "    'replaces': None,\n",
+       "    'side': <OrderSide.BUY: 'buy'>,\n",
+       "    'status': <OrderStatus.PENDING_NEW: 'pending_new'>,\n",
+       "    'stop_price': None,\n",
+       "    'submitted_at': datetime.datetime(2022, 9, 30, 2, 58, 37, 467903, tzinfo=datetime.timezone.utc),\n",
+       "    'symbol': 'ETH/USD',\n",
+       "    'time_in_force': <TimeInForce.GTC: 'gtc'>,\n",
+       "    'trail_percent': None,\n",
+       "    'trail_price': None,\n",
+       "    'type': <OrderType.MARKET: 'market'>,\n",
+       "    'updated_at': datetime.datetime(2022, 9, 30, 2, 58, 37, 469165, tzinfo=datetime.timezone.utc)}"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Buy crypto example\n",
+    "trading_client = TradingClient(alpaca_api_key, alpaca_secret_key, paper=True)\n",
+    "\n",
+    "market_order_data = MarketOrderRequest(\n",
+    "                    symbol=\"ETH/USD\",\n",
+    "                    qty=0.676,\n",
+    "                    side=OrderSide.BUY,\n",
+    "                    time_in_force=\"gtc\"\n",
+    "                    )\n",
+    "\n",
+    "# Market order\n",
+    "market_order = trading_client.submit_order( market_order_data)\n",
+    "market_order"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "3d169a71-9ec7-417b-b5d9-c2bd9e9dba1f",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[{   'asset_class': <AssetClass.CRYPTO: 'crypto'>,\n",
+       "     'asset_id': UUID('35f33a69-f5d6-4dc9-b158-4485e5e92e4b'),\n",
+       "     'avg_entry_price': '1329.2',\n",
+       "     'change_today': '-0.003000300030003',\n",
+       "     'cost_basis': '896.292852',\n",
+       "     'current_price': '1329.2',\n",
+       "     'exchange': <AssetExchange.FTXU: 'FTXU'>,\n",
+       "     'lastday_price': '1333.2',\n",
+       "     'market_value': '896.292852',\n",
+       "     'qty': '0.67431',\n",
+       "     'side': <PositionSide.LONG: 'long'>,\n",
+       "     'symbol': 'ETHUSD',\n",
+       "     'unrealized_intraday_pl': '0',\n",
+       "     'unrealized_intraday_plpc': '0',\n",
+       "     'unrealized_pl': '0',\n",
+       "     'unrealized_plpc': '0'},\n",
+       " {   'asset_class': <AssetClass.US_EQUITY: 'us_equity'>,\n",
+       "     'asset_id': UUID('b28f4066-5c6d-479b-a2af-85dc1a8f16fb'),\n",
+       "     'avg_entry_price': '368.01',\n",
+       "     'change_today': '0',\n",
+       "     'cost_basis': '8.46423',\n",
+       "     'current_price': '362.79',\n",
+       "     'exchange': <AssetExchange.ARCA: 'ARCA'>,\n",
+       "     'lastday_price': '362.79',\n",
+       "     'market_value': '8.34417',\n",
+       "     'qty': '0.023',\n",
+       "     'side': <PositionSide.LONG: 'long'>,\n",
+       "     'symbol': 'SPY',\n",
+       "     'unrealized_intraday_pl': '0',\n",
+       "     'unrealized_intraday_plpc': '0',\n",
+       "     'unrealized_pl': '-0.12006',\n",
+       "     'unrealized_plpc': '-0.0141843971631206'}]"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# List current position\n",
+    "trading_client.get_all_positions()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "70304f4e-7bd8-4f5c-910a-c66813e1e084",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{   'asset_class': <AssetClass.CRYPTO: 'crypto'>,\n",
+       "    'asset_id': UUID('a1733398-6acc-4e92-af24-0d0667f78713'),\n",
+       "    'canceled_at': None,\n",
+       "    'client_order_id': 'daf274c0-86e9-4ad0-82b2-342f3c433f66',\n",
+       "    'created_at': datetime.datetime(2022, 9, 30, 2, 59, 10, 988363, tzinfo=datetime.timezone.utc),\n",
+       "    'expired_at': None,\n",
+       "    'extended_hours': False,\n",
+       "    'failed_at': None,\n",
+       "    'filled_at': None,\n",
+       "    'filled_avg_price': None,\n",
+       "    'filled_qty': '0',\n",
+       "    'hwm': None,\n",
+       "    'id': UUID('ff81b6b3-715b-48a5-a281-72e3d1be6fe1'),\n",
+       "    'legs': None,\n",
+       "    'limit_price': None,\n",
+       "    'notional': None,\n",
+       "    'order_class': <OrderClass.SIMPLE: 'simple'>,\n",
+       "    'order_type': <OrderType.MARKET: 'market'>,\n",
+       "    'qty': '0.67431',\n",
+       "    'replaced_at': None,\n",
+       "    'replaced_by': None,\n",
+       "    'replaces': None,\n",
+       "    'side': <OrderSide.SELL: 'sell'>,\n",
+       "    'status': <OrderStatus.PENDING_NEW: 'pending_new'>,\n",
+       "    'stop_price': None,\n",
+       "    'submitted_at': datetime.datetime(2022, 9, 30, 2, 59, 10, 987054, tzinfo=datetime.timezone.utc),\n",
+       "    'symbol': 'ETH/USD',\n",
+       "    'time_in_force': <TimeInForce.GTC: 'gtc'>,\n",
+       "    'trail_percent': None,\n",
+       "    'trail_price': None,\n",
+       "    'type': <OrderType.MARKET: 'market'>,\n",
+       "    'updated_at': datetime.datetime(2022, 9, 30, 2, 59, 10, 988421, tzinfo=datetime.timezone.utc)}"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Sell crypto example\n",
+    "trading_client = TradingClient(alpaca_api_key, alpaca_secret_key, paper=True)\n",
+    "\n",
+    "market_order_data = MarketOrderRequest(\n",
+    "                    symbol=\"ETH/USD\",\n",
+    "                    qty=0.67431,\n",
+    "                    side=OrderSide.SELL,\n",
+    "                    time_in_force=\"gtc\"\n",
+    "                    )\n",
+    "\n",
+    "\n",
+    "# Market order\n",
+    "market_order = trading_client.submit_order( market_order_data)\n",
+    "market_order"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b486702a-431a-441f-9ed5-f242f2c20101",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "dev",
+   "language": "python",
+   "name": "dev"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/alpaca/alpaca_buy_sell.ipynb
+++ b/examples/alpaca/alpaca_buy_sell.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "3d2d2986-8f0f-4112-b2a2-03b767dffc76",
    "metadata": {},
    "outputs": [],
@@ -21,28 +21,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "2a1a696d-9cc5-484a-b3bf-1aa0b010162b",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "True"
-      ]
-     },
-     "execution_count": 2,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "load_dotenv()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "559f825e-3b85-4576-9416-686c4c1c822f",
    "metadata": {},
    "outputs": [],
@@ -54,52 +43,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "4d116e07-0328-4bbe-84d9-8c5d46c0eb7d",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{   'asset_class': <AssetClass.CRYPTO: 'crypto'>,\n",
-       "    'asset_id': UUID('a1733398-6acc-4e92-af24-0d0667f78713'),\n",
-       "    'canceled_at': None,\n",
-       "    'client_order_id': '9f347eff-9de9-49b9-8b1e-172e57e241c1',\n",
-       "    'created_at': datetime.datetime(2022, 9, 30, 2, 58, 37, 469102, tzinfo=datetime.timezone.utc),\n",
-       "    'expired_at': None,\n",
-       "    'extended_hours': False,\n",
-       "    'failed_at': None,\n",
-       "    'filled_at': None,\n",
-       "    'filled_avg_price': None,\n",
-       "    'filled_qty': '0',\n",
-       "    'hwm': None,\n",
-       "    'id': UUID('9d113135-171c-42a0-b30b-bc95415df4fa'),\n",
-       "    'legs': None,\n",
-       "    'limit_price': None,\n",
-       "    'notional': None,\n",
-       "    'order_class': <OrderClass.SIMPLE: 'simple'>,\n",
-       "    'order_type': <OrderType.MARKET: 'market'>,\n",
-       "    'qty': '0.676',\n",
-       "    'replaced_at': None,\n",
-       "    'replaced_by': None,\n",
-       "    'replaces': None,\n",
-       "    'side': <OrderSide.BUY: 'buy'>,\n",
-       "    'status': <OrderStatus.PENDING_NEW: 'pending_new'>,\n",
-       "    'stop_price': None,\n",
-       "    'submitted_at': datetime.datetime(2022, 9, 30, 2, 58, 37, 467903, tzinfo=datetime.timezone.utc),\n",
-       "    'symbol': 'ETH/USD',\n",
-       "    'time_in_force': <TimeInForce.GTC: 'gtc'>,\n",
-       "    'trail_percent': None,\n",
-       "    'trail_price': None,\n",
-       "    'type': <OrderType.MARKET: 'market'>,\n",
-       "    'updated_at': datetime.datetime(2022, 9, 30, 2, 58, 37, 469165, tzinfo=datetime.timezone.utc)}"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Buy crypto example\n",
     "trading_client = TradingClient(alpaca_api_key, alpaca_secret_key, paper=True)\n",
@@ -118,52 +65,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "3d169a71-9ec7-417b-b5d9-c2bd9e9dba1f",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[{   'asset_class': <AssetClass.CRYPTO: 'crypto'>,\n",
-       "     'asset_id': UUID('35f33a69-f5d6-4dc9-b158-4485e5e92e4b'),\n",
-       "     'avg_entry_price': '1329.2',\n",
-       "     'change_today': '-0.003000300030003',\n",
-       "     'cost_basis': '896.292852',\n",
-       "     'current_price': '1329.2',\n",
-       "     'exchange': <AssetExchange.FTXU: 'FTXU'>,\n",
-       "     'lastday_price': '1333.2',\n",
-       "     'market_value': '896.292852',\n",
-       "     'qty': '0.67431',\n",
-       "     'side': <PositionSide.LONG: 'long'>,\n",
-       "     'symbol': 'ETHUSD',\n",
-       "     'unrealized_intraday_pl': '0',\n",
-       "     'unrealized_intraday_plpc': '0',\n",
-       "     'unrealized_pl': '0',\n",
-       "     'unrealized_plpc': '0'},\n",
-       " {   'asset_class': <AssetClass.US_EQUITY: 'us_equity'>,\n",
-       "     'asset_id': UUID('b28f4066-5c6d-479b-a2af-85dc1a8f16fb'),\n",
-       "     'avg_entry_price': '368.01',\n",
-       "     'change_today': '0',\n",
-       "     'cost_basis': '8.46423',\n",
-       "     'current_price': '362.79',\n",
-       "     'exchange': <AssetExchange.ARCA: 'ARCA'>,\n",
-       "     'lastday_price': '362.79',\n",
-       "     'market_value': '8.34417',\n",
-       "     'qty': '0.023',\n",
-       "     'side': <PositionSide.LONG: 'long'>,\n",
-       "     'symbol': 'SPY',\n",
-       "     'unrealized_intraday_pl': '0',\n",
-       "     'unrealized_intraday_plpc': '0',\n",
-       "     'unrealized_pl': '-0.12006',\n",
-       "     'unrealized_plpc': '-0.0141843971631206'}]"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# List current position\n",
     "trading_client.get_all_positions()"
@@ -171,52 +76,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "70304f4e-7bd8-4f5c-910a-c66813e1e084",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{   'asset_class': <AssetClass.CRYPTO: 'crypto'>,\n",
-       "    'asset_id': UUID('a1733398-6acc-4e92-af24-0d0667f78713'),\n",
-       "    'canceled_at': None,\n",
-       "    'client_order_id': 'daf274c0-86e9-4ad0-82b2-342f3c433f66',\n",
-       "    'created_at': datetime.datetime(2022, 9, 30, 2, 59, 10, 988363, tzinfo=datetime.timezone.utc),\n",
-       "    'expired_at': None,\n",
-       "    'extended_hours': False,\n",
-       "    'failed_at': None,\n",
-       "    'filled_at': None,\n",
-       "    'filled_avg_price': None,\n",
-       "    'filled_qty': '0',\n",
-       "    'hwm': None,\n",
-       "    'id': UUID('ff81b6b3-715b-48a5-a281-72e3d1be6fe1'),\n",
-       "    'legs': None,\n",
-       "    'limit_price': None,\n",
-       "    'notional': None,\n",
-       "    'order_class': <OrderClass.SIMPLE: 'simple'>,\n",
-       "    'order_type': <OrderType.MARKET: 'market'>,\n",
-       "    'qty': '0.67431',\n",
-       "    'replaced_at': None,\n",
-       "    'replaced_by': None,\n",
-       "    'replaces': None,\n",
-       "    'side': <OrderSide.SELL: 'sell'>,\n",
-       "    'status': <OrderStatus.PENDING_NEW: 'pending_new'>,\n",
-       "    'stop_price': None,\n",
-       "    'submitted_at': datetime.datetime(2022, 9, 30, 2, 59, 10, 987054, tzinfo=datetime.timezone.utc),\n",
-       "    'symbol': 'ETH/USD',\n",
-       "    'time_in_force': <TimeInForce.GTC: 'gtc'>,\n",
-       "    'trail_percent': None,\n",
-       "    'trail_price': None,\n",
-       "    'type': <OrderType.MARKET: 'market'>,\n",
-       "    'updated_at': datetime.datetime(2022, 9, 30, 2, 59, 10, 988421, tzinfo=datetime.timezone.utc)}"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Sell crypto example\n",
     "trading_client = TradingClient(alpaca_api_key, alpaca_secret_key, paper=True)\n",


### PR DESCRIPTION
This is a pretty simple example of how to use Alpaca's python SDK to execute buy / sell trades for crypto.     